### PR TITLE
Rename `bytes` into something more accurate

### DIFF
--- a/src/grammar.pegjs
+++ b/src/grammar.pegjs
@@ -10,8 +10,8 @@
     const codepoints = args.map(c => parseInt(c, 16));
     const symbol = String.fromCodePoint(...codepoints);
     const unicode = args.map(c => `U+${c}`.toUpperCase());
-    const bytes = symbol.split("").map(c => escape(c))
-    return { symbol, unicode, codepoints, bytes };
+    const escaped = symbol.split("").map(c => escape(c))
+    return { symbol, unicode, codepoints, escaped };
   }
 }
 


### PR DESCRIPTION
The `bytes` property seems to represent an escaped version of the symbol, not the byte sequence in any encoding. So, `escaped` might be a better name.
